### PR TITLE
add functionality to plot bluefors compressor temperatures

### DIFF
--- a/pyplotter/sources/config.py
+++ b/pyplotter/sources/config.py
@@ -123,6 +123,14 @@ configPackage = {
                         'labelUnits' : 'Bar'},
                'ch6' : {'labelText'  : 'Venting line',
                         'labelUnits' : 'Bar'}},
+'Status' : {'cpatempwi' : {'labelText'  : 'Compressor water temperature in',
+                           'labelUnits' : u'°C'},
+            'cpatempwo' : {'labelText'  : 'Compressor water temperature out',
+                           'labelUnits' : u'°C'},
+            'cpatempo'  : {'labelText'  : 'Compressor oil temperature',
+                           'labelUnits' : u'°C'},
+            'cpatemph'  : {'labelText'  : 'Compressor helium temperature',
+                           'labelUnits' : u'°C'}},
 
 
 # Layout parameters

--- a/pyplotter/sources/widgetBlueFors.py
+++ b/pyplotter/sources/widgetBlueFors.py
@@ -147,7 +147,7 @@ class WidgetBlueFors(QtWidgets.QWidget):
 
                     for key in config[fileName]:
 
-                        self.signalUpdateProgressBar.emit(progressBar, progress, 'Downloading data: {:.0f}%'.format(progress*100))
+                        self.signalUpdateProgressBar.emit(progressBarId, progress, 'Downloading data: {:.0f}%'.format(progress*100))
                         progress += progressIteration
 
                         df_column_name = key+'_value'

--- a/pyplotter/sources/widgetBlueFors.py
+++ b/pyplotter/sources/widgetBlueFors.py
@@ -64,7 +64,6 @@ class WidgetBlueFors(QtWidgets.QWidget):
 
             fileName = file[:-13]
             filePath = os.path.join(absPath, file)
-
             # We only show file handled by the plotter
             if fileName in config.keys():
 
@@ -98,6 +97,68 @@ class WidgetBlueFors(QtWidgets.QWidget):
                                                         'x' : x,
                                                         'y' : y,
                                                         'unit' : config[fileName][name[:3]]['labelUnits']})
+
+                # Status file (compressor temperatures)
+                elif fileName=='Status':
+
+                    df = pd.read_csv(filePath,
+                                     delimiter=',',
+                                     names=['date', 'time',
+                                         'tvpower1_name', 'tvpower1_value',
+                                         'tvbearingtemp1_name', 'tvbearingtemp1_value',
+                                         'tvcontrollertemp1_name', 'tvcontrollertemp1_value',
+                                         'tvbodytemp1_name', 'tvbodytemp1_value',
+                                         'tvrot1_name', 'tvrot1_value',
+                                         'tvlife1_name', 'tvlife1_value',
+                                         'nxdsf_name', 'nxdsf_value',
+                                         'nxdsct_name', 'nxdsct_value',
+                                         'nxdst_name', 'nxdst_value',
+                                         'nxdsbs_name', 'nxdsbs_value',
+                                         'nxdstrs_name', 'nxdstrs_value',
+                                         'tc400errorcode_name', 'tc400errorcode_value',
+                                         'tc400ovtempelec_name', 'tc400ovtempelec_value',
+                                         'tc400ovtemppump_name', 'tc400ovtemppump_value',
+                                         'tc400setspdatt_name', 'tc400setspdatt_value',
+                                         'tc400pumpaccel_name', 'tc400pumpaccel_value',
+                                         'tc400commerr_name', 'tc400commerr_value',
+                                         'ctrl_pres_name', 'ctrl_pres_value',
+                                         'cpastate_name', 'cpastate_value',
+                                         'cparun_name', 'cparun_value',
+                                         'cpawarn_name', 'cpawarn_value',
+                                         'cpaerr_name', 'cpaerr_value',
+                                         'cpatempwi_name', 'cpatempwi_value',
+                                         'cpatempwo_name', 'cpatempwo_value',
+                                         'cpatempo_name', 'cpatempo_value',
+                                         'cpatemph_name', 'cpatemph_value',
+                                         'cpalp_name', 'cpalp_value',
+                                         'cpalpa_name', 'cpalpa_value',
+                                         'cpahp_name', 'cpahp_value',
+                                         'cpahpa_name', 'cpahpa_value',
+                                         'cpadp_name', 'cpadp_value',
+                                         'cpacurrent_name', 'cpacurrent_value',
+                                         'cpahours_name', 'cpahours_value',
+                                         'cpapscale_name', 'cpapscale_value',
+                                         'cpatscale_name', 'cpatscale_value',
+                                         'cpasn_name', 'cpasn_value',
+                                         'cpamodel_name', 'cpamodel_value'],
+                                     header=None)
+
+                    x = pandasTimestamp2Int(pd.to_datetime(df['date']+'-'+df['time'], format='%d-%m-%y-%H:%M:%S'))
+
+                    for key in config[fileName]:
+
+                        self.signalUpdateProgressBar.emit(progressBar, progress, 'Downloading data: {:.0f}%'.format(progress*100))
+                        progress += progressIteration
+
+                        df_column_name = key+'_value'
+                        y = df[df_column_name].to_numpy()
+                        self.paramDependentList.append({'depends_on' : ['time'],
+                                                        'name'  : config[fileName][key]['labelText'],
+                                                        'label' : config[fileName][key]['labelText'],
+                                                        'x' : x,
+                                                        'y' : y,
+                                                        'unit' : config[fileName][key]['labelUnits']})
+
                 else:
 
                     # Thermometers files


### PR DESCRIPTION
This PR includes the functionality to plot values from the status log file of Bluefors control software. For the moment, only water, oil and helium temperatures of the compressor have been implemented. For other parameters to be added to the list, just update the config-dictionary in the config.py file.